### PR TITLE
Use unicodecsv to write out utf-8 csv files

### DIFF
--- a/ckanext/recombinant/commands.py
+++ b/ckanext/recombinant/commands.py
@@ -5,6 +5,7 @@ import ckanapi
 import csv
 import sys
 import logging
+import unicodecsv
 
 from ckanext.recombinant.plugins import _get_tables
 from ckanext.recombinant.read_xls import read_xls
@@ -186,7 +187,7 @@ class TableCommand(CkanCommand):
 
         lc = ckanapi.LocalCKAN()
         for t in tables:
-            out = csv.writer(sys.stdout)
+            out = unicodecsv.writer(sys.stdout)
             #output columns header
             columns = [f['label'] for f in t['fields']]
             columns.extend(['Org id', 'Org'])

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 importlib==1.0.2
+unicodecsv
 xlwt
 xlrd


### PR DESCRIPTION
When I ran this in prod. I got unicode errors. Because of an urgent need to publish, I updated this to use the unicodecsv object instead of the usual csv writer.
