### PR TITLE
fix and forgive dirty numeric input, check authN for database update, i18n

### DIFF
--- a/ckanext/recombinant/commands.py
+++ b/ckanext/recombinant/commands.py
@@ -198,8 +198,6 @@ class TableCommand(CkanCommand):
         fields = t['fields']
 
         for n, row in enumerate(g):
-            print "row:\n\t" + str(row)
-            sys.stdin.readline()
             assert len(row) == len(fields), ("row {0} has {1} columns, "
                 "expecting {2}").format(n+3, len(row), len(fields))
             records.append(dict((

--- a/ckanext/recombinant/commands.py
+++ b/ckanext/recombinant/commands.py
@@ -196,7 +196,6 @@ class TableCommand(CkanCommand):
 
         records = []
         fields = t['fields']
-
         for n, row in enumerate(g):
             assert len(row) == len(fields), ("row {0} has {1} columns, "
                 "expecting {2}").format(n+3, len(row), len(fields))
@@ -209,15 +208,23 @@ class TableCommand(CkanCommand):
         lc.action.datastore_upsert(resource_id=resource_id, records=records)
 
     def _clean_num(self, dirty):
-        if dirty == '':
-            return dirty
-        elif isinstance(dirty, float):
+        if isinstance(dirty, float):
             return dirty
         elif isinstance(dirty, int):
             return float(dirty)
-        clean = re.sub(r'\.0$', '', str(dirty))
-        clean = re.sub(r'[^0-9]', '', clean)
-        return float(clean)
+        elif 'strip' in dir(dirty) and dirty.strip() == '':
+            return dirty.strip()
+
+        clean = re.sub(r'[^0-9]', '', re.sub(r'\.0$', '', str(dirty)))
+        # clean = re.sub(r'[^0-9]', '', clean)
+        try:
+            return float(clean)
+        except:
+            logging.warn(
+                'Bad integer input [{0}], using best-guess [{1}]'.format(
+                    dirty,
+                    clean))
+            return clean
 
     def _create_meta_dataset(self, dataset_types):
         tables = self._get_tables_from_types(dataset_types)

--- a/ckanext/recombinant/commands.py
+++ b/ckanext/recombinant/commands.py
@@ -26,7 +26,7 @@ import unicodecsv
 from docopt import docopt
 
 from ckanext.recombinant.plugins import _get_tables
-from ckanext.recombinant.read_xls import read_xls
+from ckanext.recombinant.read_xls import read_xls, clean_num
 
 RECORDS_PER_ORGANIZATION = 1000000 # max records for single datastore query
 
@@ -201,30 +201,11 @@ class TableCommand(CkanCommand):
                 "expecting {2}").format(n+3, len(row), len(fields))
             records.append(dict((
                 f['datastore_id'],
-                self._clean_num(v) if f['datastore_type'] == 'int' else v)
+                clean_num(v) if f['datastore_type'] == 'int' else v)
                 for f, v in zip(fields, row)))
 
         print name, len(records)
         lc.action.datastore_upsert(resource_id=resource_id, records=records)
-
-    def _clean_num(self, dirty):
-        if isinstance(dirty, float):
-            return dirty
-        elif isinstance(dirty, int):
-            return float(dirty)
-        elif 'strip' in dir(dirty) and dirty.strip() == '':
-            return dirty.strip()
-
-        clean = re.sub(r'[^0-9]', '', re.sub(r'\.0$', '', str(dirty)))
-        # clean = re.sub(r'[^0-9]', '', clean)
-        try:
-            return float(clean)
-        except:
-            logging.warn(
-                'Bad integer input [{0}], using best-guess [{1}]'.format(
-                    dirty,
-                    clean))
-            return clean
 
     def _create_meta_dataset(self, dataset_types):
         tables = self._get_tables_from_types(dataset_types)

--- a/ckanext/recombinant/commands.py
+++ b/ckanext/recombinant/commands.py
@@ -19,14 +19,13 @@ from ckan.logic import ValidationError
 import paste.script
 import ckanapi
 import csv
-import re
 import sys
 import logging
 import unicodecsv
 from docopt import docopt
 
 from ckanext.recombinant.plugins import _get_tables
-from ckanext.recombinant.read_xls import read_xls, clean_num
+from ckanext.recombinant.read_xls import read_xls, get_records
 
 RECORDS_PER_ORGANIZATION = 1000000 # max records for single datastore query
 
@@ -193,16 +192,7 @@ class TableCommand(CkanCommand):
             return
         p = packages[0]
         resource_id = p['resources'][0]['id']
-
-        records = []
-        fields = t['fields']
-        for n, row in enumerate(g):
-            assert len(row) == len(fields), ("row {0} has {1} columns, "
-                "expecting {2}").format(n+3, len(row), len(fields))
-            records.append(dict((
-                f['datastore_id'],
-                clean_num(v) if f['datastore_type'] == 'int' else v)
-                for f, v in zip(fields, row)))
+        records = get_records(g, t['fields'])
 
         print name, len(records)
         lc.action.datastore_upsert(resource_id=resource_id, records=records)

--- a/ckanext/recombinant/controller.py
+++ b/ckanext/recombinant/controller.py
@@ -7,7 +7,6 @@ from ckanext.recombinant.read_xls import read_xls, get_records
 from ckanext.recombinant.write_xls import xls_template
 from ckanext.recombinant.commands import _get_tables
 from ckan.logic import ValidationError
-import ckan.model
 
 from cStringIO import StringIO
 

--- a/ckanext/recombinant/controller.py
+++ b/ckanext/recombinant/controller.py
@@ -3,7 +3,7 @@ from pylons.i18n import _
 from ckan.lib.base import (c, render, model, request, h, g,
     response, abort, redirect)
 from ckan.controllers.package import PackageController
-from ckanext.recombinant.read_xls import read_xls, clean_num
+from ckanext.recombinant.read_xls import read_xls, get_records
 from ckanext.recombinant.write_xls import xls_template
 from ckanext.recombinant.commands import _get_tables
 from ckan.logic import ValidationError
@@ -24,6 +24,7 @@ class UploadController(PackageController):
             package = lc.action.package_show(id = id)
             owner_org = package['organization']['name']
 
+            """
             if (c.user is None) or (c.user == ''):
                 raise ValidationError(
                     {'xls_update': 'Login required to upload'})
@@ -35,6 +36,7 @@ class UploadController(PackageController):
                 raise ValidationError({'xls_update':
                     'You do not have permission to upload to {0}'.format(
                         owner_org)})
+            """
 
             if request.POST['xls_update'] == u'':
                 raise ValidationError({'xls_update': 'You must provide a valid file'})
@@ -58,28 +60,7 @@ class UploadController(PackageController):
 
             resource_id = package['resources'][0]['id']
 
-            records = []
-            fields = t['fields']
-            for n, row in enumerate(upload_data):
-                # trailing cells might be empty, trim them before checking length
-                while row and (row[-1] is None or row[-1] == ''):
-                    row.pop()
-
-                if len(row) != len(fields):
-                    msg = ("Row {0} of this sheet has {1} columns, "
-                            "expecting {2}").format(n+3, len(row), len(fields))
-                    raise ValidationError({'xls_update': msg})
-
-                record = {}
-                for f, v in zip(fields, row):
-                    if f['datastore_type'] == 'text':
-                        v = unicode(v)
-                    if f['datastore_type'] == 'int':
-                        record[f['datastore_id']] = clean_num(v)
-                    else:
-                        record[f['datastore_id']] = v
-                records.append(record)
-
+            records = get_records(upload_data, t['fields'])
             lc.action.datastore_upsert(resource_id=resource_id, records=records)
 
             h.flash_success(_(

--- a/ckanext/recombinant/controller.py
+++ b/ckanext/recombinant/controller.py
@@ -6,9 +6,10 @@ from ckan.controllers.package import PackageController
 from ckanext.recombinant.read_xls import read_xls, get_records
 from ckanext.recombinant.write_xls import xls_template
 from ckanext.recombinant.commands import _get_tables
-from ckan.logic import ValidationError
+from ckan.logic import ValidationError, NotAuthorized
 
 from cStringIO import StringIO
+from xlrd import XLRDError
 
 import ckanapi
 
@@ -18,63 +19,69 @@ class UploadController(PackageController):
     def upload(self, id):
         package_type = self._get_package_type(id)
         try:
-            lc = ckanapi.LocalCKAN(username = c.user)
-            package = lc.action.package_show(id = id)
+            lc = ckanapi.LocalCKAN(username=c.user)
+            package = lc.action.package_show(id=id)
             owner_org = package['organization']['name']
 
-            if not (h.check_access('package_update', {'id': id})):
-                raise ValidationError({'xls_update':
-                    _('You do not have permission to upload to {0}').format(
-                        owner_org)})
-
             if request.POST['xls_update'] == u'':
-                raise ValidationError(
-                    {'xls_update': _('You must provide a valid file')})
+                msg = 'You must provide a valid file'
+                raise ValidationError({'xls_update': {msg: ()}})
 
             upload_data = read_xls(
                 '',
                 file_contents = request.POST['xls_update'].file.read())
-            sheet_name, org_name = next(upload_data)
-
+            sheet_name, org_name = None, None
+            try:
+                sheet_name, org_name = next(upload_data)
+            except XLRDError, xerr:
+                msg = xerr.message
+                raise ValidationError({'xls_update': {msg: ()}})
 
             #is this the right sheet for this organization?
             if org_name != owner_org:
-                msg = _('Invalid sheet for this organization. ' +
+                msg = ('Invalid sheet for this organization. ' +
                     'Sheet must be labeled for {0}, ' +
-                    'but you supplied a sheet for {1}').format(
-                        owner_org,
-                        org_name)
-                raise ValidationError({'xls_update': msg})
+                    'but you supplied a sheet for {1}')
+                raise ValidationError(
+                    {'xls_update': {msg: (owner_org, org_name)}})
 
             for t in _get_tables():
                 if t['xls_sheet_name'] == sheet_name:
                     break
             else:
-                msg = _("Sheet name '{0}' not found in list of valid tables"
-                    ).format(sheet_name)
-                raise ValidationError({'xls_update': msg})
+                msg = "Sheet name '{0}' not found in list of valid tables"
+                raise ValidationError({'xls_update': {msg: (sheet_name,)}})
 
             resource_id = package['resources'][0]['id']
 
             records = get_records(upload_data, t['fields'])
-            lc.action.datastore_upsert(resource_id=resource_id, records=records)
+            try:
+                lc.action.datastore_upsert(
+                    resource_id=resource_id,
+                    records=records)
+            except NotAuthorized, na:
+                msg = 'You do not have permission to upload to {0}'
+                raise ValidationError({'xls_update': {msg: (owner_org,)}})
 
             h.flash_success(_(
                 "Your file was successfully uploaded into the central system."
                 ))
 
-            redirect(h.url_for(controller='package',
-                               action='read', id=id))
+            redirect(h.url_for(controller='package', action='read', id=id))
         except ValidationError, e:
             errors = []
             for error in e.error_dict.values():
-                errors.append(str(error).decode('utf-8'))
+                if isinstance(error, dict):
+                    errors.append(error)
+                else:
+                    errors.append(
+                        {str(error).decode('utf-8').replace('\n', '<br>'): ()})
             vars = {'errors': errors, 'action': 'edit'}
             c.pkg_dict = package
-            return render(self._edit_template(package_type), extra_vars = vars)
+            return render(self._edit_template(package_type), extra_vars=vars)
 
     def template(self, id):
-        lc = ckanapi.LocalCKAN(username = c.user)
+        lc = ckanapi.LocalCKAN(username=c.user)
         dataset = lc.action.package_show(id=id)
         org = lc.action.organization_show(id=dataset['owner_org'],
             include_datasets=False)

--- a/ckanext/recombinant/controller.py
+++ b/ckanext/recombinant/controller.py
@@ -24,8 +24,8 @@ class UploadController(PackageController):
             owner_org = package['organization']['name']
 
             if request.POST['xls_update'] == u'':
-                msg = 'You must provide a valid file'
-                raise ValidationError({'xls_update': {msg: ()}})
+                msg = _('You must provide a valid file')
+                raise ValidationError({'xls_update': msg})
 
             upload_data = read_xls(
                 '',
@@ -35,22 +35,24 @@ class UploadController(PackageController):
                 sheet_name, org_name = next(upload_data)
             except XLRDError, xerr:
                 msg = xerr.message
-                raise ValidationError({'xls_update': {msg: ()}})
+                raise ValidationError({'xls_update': msg})
 
-            #is this the right sheet for this organization?
+            # is this the right sheet for this organization?
             if org_name != owner_org:
-                msg = ('Invalid sheet for this organization. ' +
+                msg = _('Invalid sheet for this organization. ' +
                     'Sheet must be labeled for {0}, ' +
-                    'but you supplied a sheet for {1}')
+                    'but you supplied a sheet for {1}').format(
+                        owner_org, org_name)
                 raise ValidationError(
-                    {'xls_update': {msg: (owner_org, org_name)}})
+                    {'xls_update': msg})
 
             for t in _get_tables():
                 if t['xls_sheet_name'] == sheet_name:
                     break
             else:
-                msg = "Sheet name '{0}' not found in list of valid tables"
-                raise ValidationError({'xls_update': {msg: (sheet_name,)}})
+                msg = _("Sheet name '{0}' " +
+                    "not found in list of valid tables").format(sheet_name)
+                raise ValidationError({'xls_update': msg})
 
             resource_id = package['resources'][0]['id']
 
@@ -60,8 +62,8 @@ class UploadController(PackageController):
                     resource_id=resource_id,
                     records=records)
             except NotAuthorized, na:
-                msg = 'You do not have permission to upload to {0}'
-                raise ValidationError({'xls_update': {msg: (owner_org,)}})
+                msg = _('You do not have permission to upload to {0}').format(owner_org)
+                raise ValidationError({'xls_update': msg})
 
             h.flash_success(_(
                 "Your file was successfully uploaded into the central system."
@@ -71,11 +73,7 @@ class UploadController(PackageController):
         except ValidationError, e:
             errors = []
             for error in e.error_dict.values():
-                if isinstance(error, dict):
-                    errors.append(error)
-                else:
-                    errors.append(
-                        {str(error).decode('utf-8').replace('\n', '<br>'): ()})
+                errors.append(error)
             vars = {'errors': errors, 'action': 'edit'}
             c.pkg_dict = package
             return render(self._edit_template(package_type), extra_vars=vars)

--- a/ckanext/recombinant/read_xls.py
+++ b/ckanext/recombinant/read_xls.py
@@ -22,7 +22,16 @@ def read_xls(f, file_contents = None):
 
     row = sheet.horz_split_pos
     while row < sheet.nrows:
-        yield [c.value for c in sheet.row(row)]
+        # return next non-empty row
+        if not all(_is_bumf(c.value) for c in sheet.row(row)):
+            yield [c.value for c in sheet.row(row)]
         row += 1
 
+def _is_bumf(value):
+    """
+    Return true if this value is filler, en route to skipping over empty lines
+    """
+    if type(value) in (unicode, str):
+        return (value.strip() == '')
+    return (value is None)
 

--- a/ckanext/recombinant/read_xls.py
+++ b/ckanext/recombinant/read_xls.py
@@ -35,3 +35,21 @@ def _is_bumf(value):
         return (value.strip() == '')
     return (value is None)
 
+def clean_num(dirty):
+    if isinstance(dirty, float):
+        return dirty
+    elif isinstance(dirty, int):
+        return float(dirty)
+    elif 'strip' in dir(dirty) and dirty.strip() == '':
+        return dirty.strip()
+
+    clean = re.sub(r'[^0-9]', '', re.sub(r'\.0$', '', str(dirty)))
+    # clean = re.sub(r'[^0-9]', '', clean)
+    try:
+        return float(clean)
+    except:
+        logging.warn(
+            'Bad integer input [{0}], using best-guess [{1}]'.format(
+                dirty,
+                clean))
+        return clean

--- a/ckanext/recombinant/templates/recombinant/edit.html
+++ b/ckanext/recombinant/templates/recombinant/edit.html
@@ -13,9 +13,13 @@
   <header class="module-content page-header"></header>
   <section class="module-poster">
     <div class="module-content">
-
-    {% snippet "recombinant/snippets/xls_upload.html", pkg=pkg, errors=errors %}
+      {% if h.check_access('package_update', {'id': pkg.id }) %}
+        {% snippet "recombinant/snippets/xls_upload.html",
+          pkg=pkg, errors=errors %}
+      {% else %}
+        {% snippet "recombinant/snippets/xls_download.html",
+          pkg=pkg, errors=errors %}
+      {% endif %}
     </div>
   </section>
 {% endblock %}
-

--- a/ckanext/recombinant/templates/recombinant/snippets/xls_base.html
+++ b/ckanext/recombinant/templates/recombinant/snippets/xls_base.html
@@ -1,0 +1,14 @@
+<h3>{% block title %}{% endblock %}</h3>
+{% block form %}
+{% endblock %}
+  <div class="control-group dataset-form-resource-types">
+    <div class="span-1 row-start">
+      <label>{{ _('Template') }}:</label>
+    </div>
+    <div class="span-4 row-end">
+        <a class="button" href="{% url_for controller='ckanext.recombinant.controller:UploadController', action='template', id=pkg.name %}">{{ _('Download template Excel spreadsheet') }}</a></li>
+    </div>
+  {% block upload_submit %}
+  {% endblock %}
+
+</form>

--- a/ckanext/recombinant/templates/recombinant/snippets/xls_download.html
+++ b/ckanext/recombinant/templates/recombinant/snippets/xls_download.html
@@ -1,4 +1,4 @@
-{% extends 'package/snippets/xls_base.html' %}
+{% extends 'recombinant/snippets/xls_base.html' %}
 
 {% block title %}{{_('Download template Excel spreadsheet')}}{% endblock %}
 

--- a/ckanext/recombinant/templates/recombinant/snippets/xls_download.html
+++ b/ckanext/recombinant/templates/recombinant/snippets/xls_download.html
@@ -1,0 +1,11 @@
+{% extends 'package/snippets/xls_base.html' %}
+
+{% block title %}{{_('Download template Excel spreadsheet')}}{% endblock %}
+
+{% block form %}
+<form enctype="multipart/form-data" id="dataset-form" class="dataset-form dataset-resource-form form-horizontal" method="post" action=''>
+{% endblock %}
+{% block upload_submit %}
+  <div class="clear"></div>
+{% endblock %}
+

--- a/ckanext/recombinant/templates/recombinant/snippets/xls_upload.html
+++ b/ckanext/recombinant/templates/recombinant/snippets/xls_upload.html
@@ -1,4 +1,4 @@
-{% extends 'package/snippets/xls_base.html' %}
+{% extends 'recombinant/snippets/xls_base.html' %}
 
 {% block title %}{{_('Create and update records from Excel spreadsheet')}}{% endblock %}
 
@@ -12,7 +12,11 @@
     <label for="xls_update">{{ _('Upload') }}:</label>
   </div>
   <div class="span-4 row-end">
-    <input required type="file" name="xls_update" id="xls_update" accept="application/vnd.ms-excel">
+    <input required
+      type="file"
+      name="xls_update"
+      id="xls_update"
+      accept="application/vnd.ms-excel">
   </div>
   {% if errors %}
     <div class="span-3 form-attention">

--- a/ckanext/recombinant/templates/recombinant/snippets/xls_upload.html
+++ b/ckanext/recombinant/templates/recombinant/snippets/xls_upload.html
@@ -22,9 +22,7 @@
   {% if errors %}
     <div class="span-3 form-attention">
       {% for error in errors %}
-        {% for k,v in error.iteritems() %}
-          <label>{{ _(k).format(*v) }}</label>
-        {% endfor %}
+        <label>{{ error }}</label>
       {% endfor %}
     </div>
   {% endif %}

--- a/ckanext/recombinant/templates/recombinant/snippets/xls_upload.html
+++ b/ckanext/recombinant/templates/recombinant/snippets/xls_upload.html
@@ -18,10 +18,13 @@
       id="xls_update"
       accept="application/vnd.ms-excel">
   </div>
+  <div>
   {% if errors %}
     <div class="span-3 form-attention">
       {% for error in errors %}
-        <label>{{ error }}</label>
+        {% for k,v in error.iteritems() %}
+          <label>{{ _(k).format(*v) }}</label>
+        {% endfor %}
       {% endfor %}
     </div>
   {% endif %}

--- a/ckanext/recombinant/templates/recombinant/snippets/xls_upload.html
+++ b/ckanext/recombinant/templates/recombinant/snippets/xls_upload.html
@@ -1,30 +1,29 @@
-<h3>{{ _('Create and update records from Excel spreadsheet') }} </h3>
+{% extends 'package/snippets/xls_base.html' %}
+
+{% block title %}{{_('Create and update records from Excel spreadsheet')}}{% endblock %}
+
+{% block form %}
 <form enctype="multipart/form-data" id="dataset-form" class="dataset-form dataset-resource-form form-horizontal" method="post" action='{% url_for controller='ckanext.recombinant.controller:UploadController', action='upload', id=pkg.name %}'>
-  <div class="control-group dataset-form-resource-types">
-    <div class="span-1 row-start">
-      <label>{{ _('Template') }}:</label>
-    </div>
-    <div class="span-4 row-end">
-        <a class="button" href="{% url_for controller='ckanext.recombinant.controller:UploadController', action='template', id=pkg.name %}">{{ _('Download template Excel spreadsheet') }}</a></li>
-    </div>
+{% endblock %}
+
+{% block upload_submit %}
   <div class="clear"></div>
-    <div class="span-1 row-start">
-      <label for="xls_update">{{ _('Upload') }}:</label>
-    </div>
-    <div class="span-4 row-end">
-      <input required type="file" name="xls_update" id="xls_update" accept="application/vnd.ms-excel">
-    </div>
-    {% if errors %}
+  <div class="span-1 row-start">
+    <label for="xls_update">{{ _('Upload') }}:</label>
+  </div>
+  <div class="span-4 row-end">
+    <input required type="file" name="xls_update" id="xls_update" accept="application/vnd.ms-excel">
+  </div>
+  {% if errors %}
     <div class="span-3 form-attention">
       {% for error in errors %}
         <label>{{ error }}</label>
       {% endfor %}
     </div>
-    {% endif %}
+  {% endif %}
   </div>
   <div class="clear"></div>
   <div class="row">
     <input class="button button-accent button-large" type="submit" value="{{_('Submit')}}"/>
   </div>
-
-</form>
+{% endblock %}


### PR DESCRIPTION
More canonicalization for numeric input, including all-numeric input to text fields.
Internationalization for error messages in controller.py.
Only authorized package updaters may upload packages to orgs; others may download .xls template (checks in both template and in controller.py; URL hacking could bypass template).
Refactor xls_read to include record collection common to both commands.py and controller.py.
Pad/trim missing/superfluous columns from .xls input; skip empty rows.