### PR TITLE
fix and forgive dirty numeric input; skip empty lines on reading .xls fi...

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,3 +57,53 @@ Example Table Description File
 ]
 ```
 
+
+Supported Datastore Types
+-------------------------
+
+Each "fields" entry in the JSON table description file
+describes a field in the dataset. In particular, its
+"datastore_type" key codifies its type.
+
+The ckanext-recombinant extension supports the following
+data type specifications, with their respective semantics:
+
+```"datastore_type": "text"```
+The field is a text value, corresponding to a text column
+in the database. It takes no specific input format in
+the .xls template. Such fields default to a blank unicode
+string.
+
+```"datastore_type": "int"```
+The field is a numeric value, corresponding to an integer
+column in the database. It takes a .xls template format
+using space-separated digit groups; the execution
+canonicalizes content to an integer on write. Such
+fields default to zero.
+
+```"datastore_type": "year"```
+The field is a year value, corresponding to an integer
+column in the database. It takes a .xls template format
+citing a four digit integer; the execution canonicalizes
+content to an integer on write. Such fields default to zero.
+
+```"datastore_type": "month"```
+The field is a month value, corresponding to an integer
+column in the database. It takes a .xls template format
+citing a two digit integer, left-zero-padded; the execution
+canonicalizes content to an integer on write. Such fields
+default to zero.
+
+```"datastore_type": "date"```
+The field is a date value, corresponding to a text
+column in the database. It takes a .xls template format
+specifying an ISO 8601 date (yyyy-mm-dd). Such fields
+default to a blank unicode string.
+
+```"datastore_type": "money"```
+The field is a text value, corresponding to a text
+column in the database. It takes a xls template template
+format specifying a dollar sign ('$') prefix and space-
+separated digit groups; the execution reduces content
+to an integral numeric string on write. Such fields
+default to a blank unicode string.

--- a/ckanext/recombinant/commands.py
+++ b/ckanext/recombinant/commands.py
@@ -25,7 +25,8 @@ import unicodecsv
 from docopt import docopt
 
 from ckanext.recombinant.plugins import _get_tables
-from ckanext.recombinant.read_xls import read_xls
+from ckanext.recombinant.read_xls import read_xls, get_records
+from ckanext.recombinant.datatypes import data_store_type
 
 RECORDS_PER_ORGANIZATION = 1000000 # max records for single datastore query
 
@@ -131,12 +132,14 @@ class TableCommand(CkanCommand):
                     resource_id=dataset['resources'][0]['id'],
                     fields=[{
                         'id': f['datastore_id'],
-                        'type': f['datastore_type'],
+                        'type':
+                            'int' if data_store_type[
+                                f['datastore_type']].numeric
+                            else 'text',
                         } for f in t['fields']],
                     primary_key=t['datastore_primary_key'],
                     indexes=t['datastore_indexes'],
                     )
-
 
     def _destroy(self, dataset_types):
         tables = self._get_tables_from_types(dataset_types)
@@ -163,7 +166,7 @@ class TableCommand(CkanCommand):
 
     def _load_one_xls(self, name):
         g = read_xls(name)
-        sheet_name, org_name = next(g)
+        sheet_name, org_name, date_mode = next(g)
 
         for t in _get_tables():
             if t['xls_sheet_name'] == sheet_name:
@@ -192,14 +195,7 @@ class TableCommand(CkanCommand):
             return
         p = packages[0]
         resource_id = p['resources'][0]['id']
-
-        records = []
-        fields = t['fields']
-        for n, row in enumerate(g):
-            assert len(row) == len(fields), ("row {0} has {1} columns, "
-                "expecting {2}").format(n+3, len(row), len(fields))
-            records.append(dict(
-                (f['datastore_id'], v) for f, v in zip(fields, row)))
+        records = get_records(g, t['fields'], date_mode)
 
         print name, len(records)
         lc.action.datastore_upsert(resource_id=resource_id, records=records)
@@ -212,7 +208,7 @@ class TableCommand(CkanCommand):
         lc = ckanapi.LocalCKAN()
         for t in tables:
             out = unicodecsv.writer(sys.stdout)
-            #output columns header
+            # output columns header
             columns = [f['label'] for f in t['fields']]
             columns.extend(['Org id', 'Org'])
             out.writerow(columns)

--- a/ckanext/recombinant/controller.py
+++ b/ckanext/recombinant/controller.py
@@ -3,90 +3,100 @@ from pylons.i18n import _
 from ckan.lib.base import (c, render, model, request, h, g,
     response, abort, redirect)
 from ckan.controllers.package import PackageController
-from ckanext.recombinant.read_xls import read_xls
+from ckanext.recombinant.read_xls import read_xls, get_records
 from ckanext.recombinant.write_xls import xls_template
 from ckanext.recombinant.commands import _get_tables
-from ckan.logic import ValidationError
+from ckan.logic import ValidationError, NotAuthorized
 
 from cStringIO import StringIO
+from xlrd import XLRDError
 
 import ckanapi
 
 
 class UploadController(PackageController):
+    """
+    Controller for downloading Excel templates and
+    uploading packages via Excel .xls files
+    """
 
     def upload(self, id):
         package_type = self._get_package_type(id)
         try:
-            if request.POST['xls_update'] == u'':
-                raise ValidationError({'xls_update': 'You must provide a valid file'})
-
-            upload_data = read_xls('', file_contents = request.POST['xls_update'].file.read())
-            sheet_name, org_name = next(upload_data)
-
-            lc = ckanapi.LocalCKAN(username = c.user)
-            package = lc.action.package_show(id = id)
+            lc = ckanapi.LocalCKAN(username=c.user)
+            package = lc.action.package_show(id=id)
             owner_org = package['organization']['name']
 
-            #is this the right sheet for this organization?
-            if org_name != owner_org:
-                msg = ('Invalid sheet for this organization. Sheet must be labeled for {0}, ' +
-                       'but you supplied a sheet for {1}').format(owner_org, org_name)
+            if request.POST['xls_update'] == u'':
+                msg = _('You must provide a valid file')
                 raise ValidationError({'xls_update': msg})
+
+            upload_data = read_xls(
+                '',
+                file_contents=request.POST['xls_update'].file.read())
+            sheet_name, org_name, date_mode = None, None, None
+            try:
+                sheet_name, org_name, date_mode = next(upload_data)
+            except XLRDError, xerr:
+                msg = xerr.message
+                raise ValidationError({'xls_update': msg})
+
+            # is this the right sheet for this organization?
+            if org_name != owner_org:
+                msg = _(
+                    'Invalid sheet for this organization. ' +
+                    'Sheet must be labeled for {0}, ' +
+                    'but you supplied a sheet for {1}').format(
+                        owner_org, org_name)
+                raise ValidationError(
+                    {'xls_update': msg})
 
             for t in _get_tables():
                 if t['xls_sheet_name'] == sheet_name:
                     break
             else:
-                msg = "Sheet name '{0}' not found in list of valid tables".format(sheet_name)
+                msg = _(
+                    "Sheet name '{0}' " +
+                    "not found in list of valid tables").format(sheet_name)
                 raise ValidationError({'xls_update': msg})
 
             resource_id = package['resources'][0]['id']
 
-            records = []
-            fields = t['fields']
-            for n, row in enumerate(upload_data):
-                # trailing cells might be empty, trim them before checking length
-                while row and (row[-1] is None or row[-1] == ''):
-                    row.pop()
-
-                if len(row) != len(fields):
-                    msg = ("Row {0} of this sheet has {1} columns, "
-                            "expecting {2}").format(n+3, len(row), len(fields))
-                    raise ValidationError({'xls_update': msg})
-
-                record = {}
-                for f, v in zip(fields, row):
-                    if f['datastore_type'] == 'text':
-                        v = unicode(v)
-                    record[f['datastore_id']] = v
-                records.append(record)
-
-            lc.action.datastore_upsert(resource_id=resource_id, records=records)
+            records = get_records(upload_data, t['fields'], date_mode)
+            try:
+                lc.action.datastore_upsert(
+                    resource_id=resource_id,
+                    records=records)
+            except NotAuthorized, na:
+                msg = _(
+                    'You do not have permission to upload to {0}').format(
+                        owner_org)
+                raise ValidationError({'xls_update': msg})
 
             h.flash_success(_(
                 "Your file was successfully uploaded into the central system."
                 ))
 
-            redirect(h.url_for(controller='package',
-                               action='read', id=id))
+            redirect(h.url_for(controller='package', action='read', id=id))
         except ValidationError, e:
-            errors = []
-            for error in e.error_dict.values():
-                errors.append(str(error).decode('utf-8'))
-            vars = {'errors': errors, 'action': 'edit'}
+            x_vars = {'errors': e.error_dict.values(), 'action': 'edit'}
             c.pkg_dict = package
-            return render(self._edit_template(package_type), extra_vars = vars)
+            return render(self._edit_template(package_type), extra_vars=x_vars)
 
     def template(self, id):
-        lc = ckanapi.LocalCKAN(username = c.user)
+        lc = ckanapi.LocalCKAN(username=c.user)
         dataset = lc.action.package_show(id=id)
-        org = lc.action.organization_show(id=dataset['owner_org'],
+        org = lc.action.organization_show(
+            id=dataset['owner_org'],
             include_datasets=False)
 
         book = xls_template(dataset['type'], org)
         blob = StringIO()
         book.save(blob)
         response.headers['Content-Type'] = 'application/vnd.ms-excel'
+        response.headers['Content-Disposition'] = (
+            'inline; filename="{0}.{1}.xls"'.format(
+                dataset['organization']['name'],
+                dataset['type']))
         return blob.getvalue()
 

--- a/ckanext/recombinant/datatypes.py
+++ b/ckanext/recombinant/datatypes.py
@@ -1,0 +1,28 @@
+from collections import namedtuple
+
+
+class DataStoreType(namedtuple(
+        'DataStoreType',
+        ['tag', 'numeric', 'default', 'xl_format'])):
+    """
+    Codifies data store types available in recombinant-tables JSON
+    specification:
+        'tag': the content of the datastore_type value
+        'numeric': if content is a number, whether to retain
+            trailing .0 padding for xlrd float coercion
+        'default': default value to use if blank
+        'xl_format': Excel custom format string to apply
+    """
+    pass
+
+data_store_type = {
+    'year': DataStoreType('year', True, 0.0, '###0'),
+    'month': DataStoreType('month', True, 0.0, '00'),
+    'date': DataStoreType('date', False, u'', 'yyyy-mm-dd'),
+    'int': DataStoreType('int', True, 0.0, '### ### ### ### ### ##0'),
+    'money': DataStoreType(
+        'money',
+        False,
+        u'',
+        '[<1000]$##0;[<1000000]$### ##0;$### ### ##0'),
+    'text': DataStoreType('text', False, u'', None)}

--- a/ckanext/recombinant/read_xls.py
+++ b/ckanext/recombinant/read_xls.py
@@ -1,14 +1,25 @@
 
+import re
 import xlrd
-
+from datetime import datetime, date
+from datatypes import  data_store_type
 
 # special place to look for the organization name in each XLS file
 ORG_NAME_CELL = (0, 2)
 
-def read_xls(f, file_contents = None):
+
+def read_xls(f, file_contents=None):
     """
     Return a generator that opens the xls file f
-    and then produces ((sheet-name, org-name), row1, row2, ...)
+    and then produces ((sheet-name, org-name, date-mode), row1, row2, ...)
+    :param: f: file name
+    :type f: string
+    :param: file_contents: content of workbook
+    :type file_contents: string
+
+    :return: Generator that opens the xls file f
+    and then produces ((sheet-name, org-name, date-mode), row1, row2, ...)
+    :rtype: generator
     """
     if file_contents is not None:
         wb = xlrd.open_workbook(file_contents= file_contents)
@@ -18,11 +29,114 @@ def read_xls(f, file_contents = None):
 
     sheet = wb.sheet_by_index(0)
     org_name_cell = sheet.cell(*ORG_NAME_CELL)
-    yield (sheet.name, org_name_cell.value)
+    yield (sheet.name, org_name_cell.value, wb.datemode)
 
     row = sheet.horz_split_pos
     while row < sheet.nrows:
-        yield [c.value for c in sheet.row(row)]
+        # return next non-empty row
+        if not all(_is_bumf(c.value) for c in sheet.row(row)):
+            yield [c.value for c in sheet.row(row)]
         row += 1
 
 
+def _is_bumf(value):
+    """
+    Return true if this value is filler, en route to skipping over empty lines
+
+    :param value: value to check
+    :type value: object
+
+    :return: whether the value is filler
+    :rtype: bool
+    """
+    if type(value) in (unicode, str):
+        return value.strip() == ''
+    return value is None
+
+
+def _canonicalize(dirty, dstore_tag, date_mode):
+    """
+    Canonicalize dirty input from xlrd to align with
+    recombinant.json datastore type specified in dstore_tag.
+
+    The date_mode adheres to the xlrd Excel workbook; it has value 1
+    if the workbook originates on Excel for Macinstosh and 0 otherwise.
+
+    :param dirty: dirty cell content as read through xlrd
+    :type dirty: object
+    :param dstore_tag: datastore_type specifier in (JSON) schema for cell
+    :type dstore_tag: str
+    :param date_mode: Excel workbook date mode attribute
+    :type date_mode: integer
+
+    :return: Canonicalized cell input
+    :rtype: float or unicode
+    """
+    dtype = data_store_type[dstore_tag]
+    if dirty is None:
+        return dtype.default
+    elif isinstance(dirty, float) or isinstance(dirty, int):
+        if dtype.numeric:
+            return float(dirty)
+        elif dtype.tag == 'date':
+            # excel returns dates as floats - convert back
+            dt = datetime(*xlrd.xldate_as_tuple(dirty, date_mode))
+            return unicode(dt.date())
+        else:
+            # JSON specifies text or money: content of origin is numeric string.
+            # If xlrd has added .0 to present content as a float,
+            # trim it before returning as numeric string
+            if int(dirty) == dirty:
+                return unicode(int(dirty))
+            else:
+                return unicode(dirty)
+    elif (isinstance(dirty, basestring)) and (dirty.strip() == ''):
+        # Content trims to empty: default
+        return dtype.default
+    elif not dtype.numeric:
+        if dtype.tag == 'money':
+            # User has overridden Excel format string, probably adding currency
+            # markers or digit group separators (e.g.,fr-CA uses 1$ (not $1)).
+            # Truncate any trailing decimal digits, retain int
+            # part, and cast as numeric string.
+            canon = re.sub(r'[^0-9]', '', re.sub(r'\.[0-9 ]+$', '', str(dirty)))
+            return unicode(canon)
+        return unicode(dirty)
+
+    # dirty is numeric: truncate trailing decimal digits, retain int part
+    canon = re.sub(r'[^0-9]', '', re.sub(r'\.[0-9 ]+$', '', str(dirty)))
+    return float(canon)
+
+
+def get_records(upload_data, fields, date_mode):
+    """
+    Truncate/pad empty/missing records to expected row length, canonicalize
+    cell content, and return resulting record list.
+
+    :param upload_data: generator producing rows of content
+    :type upload_data: generator
+    :param fields: collection of fields specified in JSON schema
+    :type fields: list or tuple
+    :param date_mode: Excel workbook date mode attribute
+    :type date_mode: int
+
+    :return: canonicalized records of specified upload data
+    :rtype: tuple of dicts
+    """
+    records = []
+    for n, row in enumerate(upload_data):
+        # trailing cells might be empty: trim row to fit
+        while (row and
+                (len(row) > len(fields)) and
+                (row[-1] is None or row[-1] == '')):
+            row.pop()
+        while row and (len(row) < len(fields)):
+            row.append(None) # placeholder: canonicalize once only, below
+
+        records.append(
+            dict((
+                f['datastore_id'],
+                _canonicalize(v, f['datastore_type'], date_mode))
+            for f, v in zip(fields, row)))
+
+    return records

--- a/ckanext/recombinant/recombinant_tables.json
+++ b/ckanext/recombinant/recombinant_tables.json
@@ -1,41 +1,215 @@
 [
   {
-    "xls_sheet_name": "ATI AI",
     "dataset_type": "ati-summaries",
     "title": "ATI Summaries",
-    "datastore_table": {
-      "fields": [
-        {
-          "id": "year",
-          "type": "int"
-        },
-        {
-          "id": "month",
-          "type": "int"
-        },
-        {
-          "id": "request_number",
-          "type": "text"
-        },
-        {
-          "id": "summary",
-          "type": "text"
-        },
-        {
-          "id": "summary_fra",
-          "type": "text"
-        },
-        {
-          "id": "disposition",
-          "type": "text"
-        },
-        {
-          "id": "pages",
-          "type": "int"
-        }
+    "xls_sheet_name": "ATI AI",
+    "fields": [
+      {
+        "datastore_id": "year",
+        "label": "Year / Année",
+        "datastore_type": "year",
+        "xls_column_width": 13
+      },
+      {
+        "datastore_id": "month",
+        "label": "Month / Mois",
+        "datastore_type": "month",
+        "xls_column_width": 13
+      },
+      {
+        "datastore_id": "request_number",
+        "label": "Request Number / Numero de la demande",
+        "datastore_type": "text",
+        "xls_column_width": 38
+      },
+      {
+        "datastore_id": "summary_eng",
+        "label": "English Summary / Sommaire de la demande en anglais",
+        "datastore_type": "text",
+        "xls_column_width": 41
+      },
+      {
+        "datastore_id": "summary_fra",
+        "label": "French Summary / Sommaire de la demande en français",
+        "datastore_type": "text",
+        "xls_column_width": 41
+      },
+      {
+        "datastore_id": "disposition",
+        "label": "Disposition",
+        "datastore_type": "text",
+        "xls_column_width": 39
+      },
+      {
+        "datastore_id": "pages",
+        "label": "Number of Pages / Nombre de pages",
+        "datastore_type": "int",
+        "xls_column_width": 34
+      }
+    ],
+    "datastore_primary_key": "request_number",
+    "datastore_indexes": "",
+    "xls_organization_info":
+      [
+        "department_number",
+        null,
+        "name",
+        "title",
+        null,
+        null,
+        null
       ],
-      "primary_key": "request_number",
-      "indexes": "request_number"
-    }
+    "xls_organization_style": "pattern: pattern solid, fore_color light_green;",
+    "xls_header_style": "font: bold on; pattern: pattern solid, fore_color light_green;"
+  },
+  {
+    "dataset_type": "ati-none",
+    "title": "ATI Nothing to Report",
+    "xls_sheet_name": "ATI AI none",
+    "fields": [
+      {
+        "datastore_id": "year",
+        "label": "Year / Année",
+        "datastore_type": "year",
+        "xls_column_width": 5
+      },
+      {
+        "datastore_id": "month",
+        "label": "Month / Mois",
+        "datastore_type": "month",
+        "xls_column_width": 4
+      }
+    ],
+    "datastore_primary_key": ["year", "month"],
+    "datastore_indexes": "",
+    "xls_organization_info": ["dept_id", null, "name", "title"],
+    "xls_organization_style": "pattern: pattern solid, fore_color gray25;",
+    "xls_header_style": "font: bold on; pattern: pattern solid, fore_color light_green;"
+  },
+  {
+    "dataset_type": "contracts",
+    "title": "Contracts",
+    "xls_sheet_name": "contracts",
+    "fields": [
+      {
+        "datastore_id": "ref_number",
+        "label": "Reference Number / Numéro de référence",
+        "datastore_type": "text",
+        "xls_column_width": 20
+      },
+      {
+        "datastore_id": "vendor_name_en",
+        "label": "English Vendor Name / Nom du fournisseur en anglais",
+        "datastore_type": "text",
+        "xls_column_width": 20
+      },
+      {
+        "datastore_id": "vendor_name_fr",
+        "label": "French Vendor Name / Nom du fournisseur en français",
+        "datastore_type": "text",
+        "xls_column_width": 20
+      },
+      {
+        "datastore_id": "description_code",
+        "label": "Economic Object Code / Code d'objet économique",
+        "datastore_type": "text",
+        "xls_column_width": 20
+      },
+      {
+        "datastore_id": "description_en",
+        "label": "English Description / Description anglaise",
+        "datastore_type": "text",
+        "xls_column_width": 20
+      },
+      {
+        "datastore_id": "description_fr",
+        "label": "French Description / Description française",
+        "datastore_type": "text",
+        "xls_column_width": 20
+      },
+      {
+        "datastore_id": "description_more_en",
+        "label": "English Description More / Description avancée en anglais",
+        "datastore_type": "text",
+        "xls_column_width": 20
+      },
+      {
+        "datastore_id": "description_more_fr",
+        "label": "French Description More / Description avancée en français",
+        "datastore_type": "text",
+        "xls_column_width": 20
+      },
+      {
+        "datastore_id": "contract_date",
+        "label": "Contract Date / Date du contrat",
+        "datastore_type": "date",
+        "xls_column_width": 20
+      },
+      {
+        "datastore_id": "contract_period_start",
+        "label": "Contract Period Start / Date de début du contrat",
+        "datastore_type": "date",
+        "xls_column_width": 20
+      },
+      {
+        "datastore_id": "contract_period_end",
+        "label": "Contract Period End / Date de clôture du contrat",
+        "datastore_type": "date",
+        "xls_column_width": 20
+      },
+      {
+        "datastore_id": "delivery_date",
+        "label": "Delivery Date / Date de livraison",
+        "datastore_type": "date",
+        "xls_column_width": 20
+      },
+      {
+        "datastore_id": "contract_value",
+        "label": "Contract Value / Valeur du contrat",
+        "datastore_type": "money",
+        "xls_column_width": 20
+      },
+      {
+        "datastore_id": "original_value",
+        "label": "Original Value / Valeur d'origine",
+        "datastore_type": "money",
+        "xls_column_width": 20
+      },
+      {
+        "datastore_id": "cumulative_value",
+        "label": "Cumulative Value / Valeur cumulative",
+        "datastore_type": "money",
+        "xls_column_width": 20
+      },
+      {
+        "datastore_id": "comments_en",
+        "label": "English Comments / Commentaires en anglais",
+        "datastore_type": "text",
+        "xls_column_width": 20
+      },
+      {
+        "datastore_id": "comments_fr",
+        "label": "French Comments / Commentaires en français",
+        "datastore_type": "text",
+        "xls_column_width": 20
+      },
+      {
+        "datastore_id": "additional_comments_en",
+        "label": "English Additional Comments / Commentaires additionnels en anglais",
+        "datastore_type": "text",
+        "xls_column_width": 20
+      },
+      {
+        "datastore_id": "additional_comments_fr",
+        "label": "French Additional Comments / Commentaires additionnels en français",
+        "datastore_type": "text",
+        "xls_column_width": 20
+      }
+    ],
+    "datastore_primary_key": ["ref_number"],
+    "datastore_indexes": "",
+    "xls_organization_info": ["dept_id", null, "name", "title"],
+    "xls_organization_style": "pattern: pattern solid, fore_color gray25;",
+    "xls_header_style": "font: bold on; pattern: pattern solid, fore_color light_blue;"
   }
 ]

--- a/ckanext/recombinant/templates/recombinant/edit.html
+++ b/ckanext/recombinant/templates/recombinant/edit.html
@@ -13,9 +13,13 @@
   <header class="module-content page-header"></header>
   <section class="module-poster">
     <div class="module-content">
-
-    {% snippet "recombinant/snippets/xls_upload.html", pkg=pkg, errors=errors %}
+      {% if h.check_access('package_update', {'id': pkg.id }) %}
+        {% snippet "recombinant/snippets/xls_upload.html",
+          pkg=pkg, errors=errors %}
+      {% else %}
+        {% snippet "recombinant/snippets/xls_download.html",
+          pkg=pkg, errors=errors %}
+      {% endif %}
     </div>
   </section>
 {% endblock %}
-

--- a/ckanext/recombinant/templates/recombinant/snippets/xls_base.html
+++ b/ckanext/recombinant/templates/recombinant/snippets/xls_base.html
@@ -1,0 +1,14 @@
+<h3>{% block title %}{% endblock %}</h3>
+{% block form %}
+{% endblock %}
+  <div class="control-group dataset-form-resource-types">
+    <div class="span-1 row-start">
+      <label>{{ _('Template') }}:</label>
+    </div>
+    <div class="span-4 row-end">
+        <a class="button" href="{% url_for controller='ckanext.recombinant.controller:UploadController', action='template', id=pkg.name %}">{{ _('Download template Excel spreadsheet') }}</a></li>
+    </div>
+  {% block upload_submit %}
+  {% endblock %}
+
+</form>

--- a/ckanext/recombinant/templates/recombinant/snippets/xls_download.html
+++ b/ckanext/recombinant/templates/recombinant/snippets/xls_download.html
@@ -1,0 +1,11 @@
+{% extends 'recombinant/snippets/xls_base.html' %}
+
+{% block title %}{{_('Download template Excel spreadsheet')}}{% endblock %}
+
+{% block form %}
+<form enctype="multipart/form-data" id="dataset-form" class="dataset-form dataset-resource-form form-horizontal" method="post" action=''>
+{% endblock %}
+{% block upload_submit %}
+  <div class="clear"></div>
+{% endblock %}
+

--- a/ckanext/recombinant/templates/recombinant/snippets/xls_upload.html
+++ b/ckanext/recombinant/templates/recombinant/snippets/xls_upload.html
@@ -1,30 +1,34 @@
-<h3>{{ _('Create and update records from Excel spreadsheet') }} </h3>
+{% extends 'recombinant/snippets/xls_base.html' %}
+
+{% block title %}{{_('Create and update records from Excel spreadsheet')}}{% endblock %}
+
+{% block form %}
 <form enctype="multipart/form-data" id="dataset-form" class="dataset-form dataset-resource-form form-horizontal" method="post" action='{% url_for controller='ckanext.recombinant.controller:UploadController', action='upload', id=pkg.name %}'>
-  <div class="control-group dataset-form-resource-types">
-    <div class="span-1 row-start">
-      <label>{{ _('Template') }}:</label>
-    </div>
-    <div class="span-4 row-end">
-        <a class="button" href="{% url_for controller='ckanext.recombinant.controller:UploadController', action='template', id=pkg.name %}">{{ _('Download template Excel spreadsheet') }}</a></li>
-    </div>
+{% endblock %}
+
+{% block upload_submit %}
   <div class="clear"></div>
-    <div class="span-1 row-start">
-      <label for="xls_update">{{ _('Upload') }}:</label>
-    </div>
-    <div class="span-4 row-end">
-      <input required type="file" name="xls_update" id="xls_update" accept="application/vnd.ms-excel">
-    </div>
-    {% if errors %}
+  <div class="span-1 row-start">
+    <label for="xls_update">{{ _('Upload') }}:</label>
+  </div>
+  <div class="span-4 row-end">
+    <input required
+      type="file"
+      name="xls_update"
+      id="xls_update"
+      accept="application/vnd.ms-excel">
+  </div>
+  <div>
+  {% if errors %}
     <div class="span-3 form-attention">
       {% for error in errors %}
         <label>{{ error }}</label>
       {% endfor %}
     </div>
-    {% endif %}
+  {% endif %}
   </div>
   <div class="clear"></div>
   <div class="row">
     <input class="button button-accent button-large" type="submit" value="{{_('Submit')}}"/>
   </div>
-
-</form>
+{% endblock %}

--- a/ckanext/recombinant/write_xls.py
+++ b/ckanext/recombinant/write_xls.py
@@ -2,12 +2,13 @@ import xlwt
 
 from ckanext.recombinant.plugins import get_table
 from ckanext.recombinant.errors import RecombinantException
+from ckanext.recombinant.datatypes import data_store_type
 
 XLS_0_WIDTH = 256  # width of '0' character in default font
 
 def xls_template(dataset_type, org):
     """
-    return an xlwn.Workbook object containing the sheet and header fields
+    return an xlwt.Workbook object containing the sheet and header fields
     for passed dataset_type and org.
     """
     t = get_table(dataset_type)
@@ -26,6 +27,9 @@ def xls_template(dataset_type, org):
     for n, field in enumerate(t['fields']):
         sheet.write(1, n, field['label'], header_xf)
         sheet.col(n).width = field['xls_column_width'] * XLS_0_WIDTH
+        sheet.col(n).set_style(
+            xlwt.easyxf(num_format_str=data_store_type[
+                field['datastore_type']].xl_format))
 
     sheet.set_panes_frozen(True)  # frozen headings instead of split panes
     sheet.set_horz_split_pos(2)  # in general, freeze after last heading row


### PR DESCRIPTION
...les

remove extraneous print-and-wait step

exception handling in extraneous case, use best-guess

Initial fix for ticket #761 (anon users could submit ATI files to orgs), propagate fix-dirty-numeric-input behaviour to GUI-driven experience

Check read permission at least to allow upload of spreadsheets

Back out ersatz authN call for the moment; investigate CKAN lib helper function to that end.
Trim/default-pad long/short rows in excel spreadsheet read.
Canonicalize all-numeric text input to text if data type expects such.
Collect records as method in read_xls.py for commands.py and controller.py to call.

i18n text updates for controller, templates

remove import ckan.model, now unused

i18n for error messages where possible, let template handle unicode

i18n for error messages where possible, let template handle unicode

interpolate error messages in controller and pass fait-accompli as strings to template, rather than dicts that require iteration in jinja2

Accomodate diverse datatypes in recombinant json. Complete JSON schema datatype diversification, integrate with psql db creation.

default to descriptive file name for template download

Accent on Annee in recombinant_tables.json

full import path to datatypes.py