### PR TITLE
reusing resource ids, needs further testing

### DIFF
--- a/ckanext/recombinant/logic.py
+++ b/ckanext/recombinant/logic.py
@@ -1,3 +1,4 @@
+import uuid
 from pylons.i18n import _
 
 from ckanapi import LocalCKAN, NotFound, ValidationError
@@ -24,11 +25,17 @@ def recombinant_create(context, data_dict):
             _("dataset type %s already exists for this organization")
             % data_dict['dataset_type']})
 
-    resources = [_resource_fields(chromo) for chromo in geno['resources']]
+    # generate stable resource ids based on org id + resource_name
+    owner_org = data_dict['owner_org']
+    org = lc.action.organization_show(id=owner_org)
+    resources = [
+        dict(_resource_fields(chromo), id=str(
+            uuid.uuid5(uuid.UUID(org['id']), chromo['resource_name'])))
+        for chromo in geno['resources']]
 
     dataset = lc.action.package_create(
         type=data_dict['dataset_type'],
-        owner_org=data_dict['owner_org'],
+        owner_org=owner_org,
         resources=resources,
         **_dataset_fields(geno))
 


### PR DESCRIPTION
I can force resource ids to the same values on all sites, and when recreating datasets. It's certainly nice when we need to make major changes to the schema to not also break ids clients are using.

What I'm not sure of is how this interacts with vdm when we delete a resource that belonged to one dataset then re-create it attached to a different dataset. Seems dangerous.