### PR TITLE
OPN-286: only show labels under 'reporting period' references

### DIFF
--- a/ckanext/recombinant/templates/recombinant/snippets/choices_reference.html
+++ b/ckanext/recombinant/templates/recombinant/snippets/choices_reference.html
@@ -24,8 +24,10 @@
     <details><summary>{{ f.label }}</summary>
       <dl class="mrgn-tp-md mrgn-bttm-0">
         {% for value, label in f.choices[:1000] %}
-          <dt>{{ value }}</dt>
-          <dd>{{ label }}</dd>
+          {% if 'Reporting Period' != f.label  %}
+            <dt>{{ value }}</dt>
+          {% endif %}
+        <dd>{{ label }}</dd>
         {% endfor %}
       </dl>
     </details>


### PR DESCRIPTION
This is to avoid duplication since the label and value are the same here. 