### PR TITLE
Add help text for `clear_datastore` command

### DIFF
--- a/ckanext/recombinant/plugins.py
+++ b/ckanext/recombinant/plugins.py
@@ -104,6 +104,7 @@ class RecombinantPlugin(
             'recombinant_create': logic.recombinant_create,
             'recombinant_update': logic.recombinant_update,
             'recombinant_show': logic.recombinant_show,
+            'clear_datastore': logic.clear_datastore,
             }
 
 

--- a/ckanext/recombinant/templates/recombinant/snippets/api_access.html
+++ b/ckanext/recombinant/templates/recombinant/snippets/api_access.html
@@ -96,11 +96,11 @@ result = ckan.action.datastore_upsert(
 )</pre>
 
   <h4>{{ _("Delete Records") }}</h4>
-  <p>{% trans %}First verify that the record you would like to remove is present with the "datastore_search" endpoint{% endtrans %}<p>
+  <p>{% trans %}Remove the record by passing the resource_id and any filters to the "clear_datastore" endpoint.{% endtrans %}</p>
 
   <h5>{{ _("Example:") }}</h5>
   <pre class="curl"
->curl {{ g.site_url }}/api/action/datastore_search \
+>curl {{ g.site_url }}/api/action/clear_datastore \
  -H"Authorization:$API_KEY" -d '
 {
   "resource_id": "{{ resource_id }}",
@@ -113,46 +113,17 @@ result = ckan.action.datastore_upsert(
 >$json = @'
 {
   "resource_id": "{{ resource_id }}",
-  "records": [{
-{{ h.recombinant_example(resource.name, 'filter_one', indent=4) }}
-  }]
-}
-'@
-$response = Invoke-RestMethod {{ g.site_url }}/api/action/datastore_search `
-  -Method Post -Body $json -Headers @{"Authorization"="$API_KEY"}
-$response.result.records
-</pre>
-  <pre class="python"
->from ckanapi import RemoteCKAN
-from pprint import pprint
-ckan = RemoteCKAN('{{ g.site_url }}', apikey=API_KEY)
-result = ckan.action.datastore_search(
-    resource_id="{{ resource_id }}",
-    filters={
-{{ h.recombinant_example(resource.name, 'filter_one', indent=8) }}
-    }
-)
-pprint(result['records'])</code></pre>
-
-  <p>{% trans %}Remove the record returned by passing the same parameters to the "datastore_delete" endpoint instead of "datastore_search".{% endtrans %}</p>
-
-  <h5>{{ _("Example:") }}</h5>
-  <pre class="bash"
->curl {{ g.site_url }}/api/action/datastore_delete \
- -H"Authorization:$API_KEY" -d '
-{
-  "resource_id": "{{ resource_id }}",
   "filters": {
 {{ h.recombinant_example(resource.name, 'filter_one', indent=4) }}
   }
-}'
-</pre>
-  <pre class="powershell"
->$response = Invoke-RestMethod {{ g.site_url }}/api/action/datastore_delete `
+'@
+>$response = Invoke-RestMethod {{ g.site_url }}/api/action/clear_datastore `
   -Method Post -Body $json -Headers @{"Authorization"="$API_KEY"}
 </pre>
   <pre class="python"
->ckan.action.datastore_delete(
+>from ckanapi import RemoteCKAN
+ckan = RemoteCKAN('{{ g.site_url }}', apikey=API_KEY)
+ckan.action.clear_datastore(
     resource_id="{{ resource_id }}",
     filters={
 {{ h.recombinant_example(resource.name, 'filter_one', indent=8) }}


### PR DESCRIPTION
Added `clear_datastore` command and logic action. This action will never drop the table in the datastore, it will only delete rows of data. Updated the Recombinant API Help tab.