### PR TITLE
API Help Text for `datatore_records_delete`

### DIFF
--- a/ckanext/recombinant/i18n/ckanext-recombinant.pot
+++ b/ckanext/recombinant/i18n/ckanext-recombinant.pot
@@ -1,15 +1,15 @@
 # Translations template for ckanext-recombinant.
-# Copyright (C) 2020 ORGANIZATION
+# Copyright (C) 2023 ORGANIZATION
 # This file is distributed under the same license as the ckanext-recombinant
 # project.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2020.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2023.
 #
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: ckanext-recombinant 2.0.0.dev0\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-05-14 13:59-0400\n"
+"POT-Creation-Date: 2023-01-26 15:39+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,11 +18,11 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.3.4\n"
 
-#: ckanext/recombinant/controller.py:55
+#: ckanext/recombinant/controller.py:54
 msgid "No errors found."
 msgstr ""
 
-#: ckanext/recombinant/controller.py:59
+#: ckanext/recombinant/controller.py:58
 msgid "Your file was successfully uploaded into the central system."
 msgstr ""
 
@@ -47,43 +47,43 @@ msgstr ""
 msgid "Multiple matching records found"
 msgstr ""
 
-#: ckanext/recombinant/controller.py:163
+#: ckanext/recombinant/controller.py:164
 msgid "{num} deleted."
 msgstr ""
 
-#: ckanext/recombinant/controller.py:183 ckanext/recombinant/controller.py:194
+#: ckanext/recombinant/controller.py:184 ckanext/recombinant/controller.py:195
 msgid "Not found"
 msgstr ""
 
-#: ckanext/recombinant/controller.py:220
+#: ckanext/recombinant/controller.py:221
 msgid "Not authorized"
 msgstr ""
 
-#: ckanext/recombinant/controller.py:240 ckanext/recombinant/controller.py:252
+#: ckanext/recombinant/controller.py:241 ckanext/recombinant/controller.py:253
 msgid "Recombinant dataset_type not found"
 msgstr ""
 
-#: ckanext/recombinant/controller.py:263 ckanext/recombinant/controller.py:286
+#: ckanext/recombinant/controller.py:264 ckanext/recombinant/controller.py:287
 msgid "title"
 msgstr ""
 
-#: ckanext/recombinant/controller.py:264
+#: ckanext/recombinant/controller.py:265
 msgid "notes"
 msgstr ""
 
-#: ckanext/recombinant/controller.py:344
+#: ckanext/recombinant/controller.py:345
 msgid "No organizations found"
 msgstr ""
 
-#: ckanext/recombinant/controller.py:348 ckanext/recombinant/controller.py:361
+#: ckanext/recombinant/controller.py:349 ckanext/recombinant/controller.py:362
 msgid "Recombinant resource_name not found"
 msgstr ""
 
-#: ckanext/recombinant/controller.py:389
+#: ckanext/recombinant/controller.py:390
 msgid "Resource not found"
 msgstr ""
 
-#: ckanext/recombinant/controller.py:431
+#: ckanext/recombinant/controller.py:432
 msgid ""
 "The server encountered a problem processing the file uploaded. Please try "
 "copying your data into the latest version of the template and uploading "
@@ -91,34 +91,34 @@ msgid ""
 "sct.gc.ca so we may investigate."
 msgstr ""
 
-#: ckanext/recombinant/controller.py:438
+#: ckanext/recombinant/controller.py:439
 msgid ""
 "Invalid file for this data type. Sheet must be labeled \"{0}\", but you "
 "supplied a sheet labeled \"{1}\""
 msgstr ""
 
-#: ckanext/recombinant/controller.py:445
+#: ckanext/recombinant/controller.py:446
 msgid ""
 "Invalid sheet for this organization. Sheet must be labeled for {0}, but you "
 "supplied a sheet for {1}"
 msgstr ""
 
-#: ckanext/recombinant/controller.py:461
+#: ckanext/recombinant/controller.py:462
 msgid ""
 "This template is out of date. Please try copying your data into the latest "
 "version of the template and uploading again. If this problem continues, send "
 "your Excel file to open-ouvert@tbs-sct.gc.ca so we may investigate."
 msgstr ""
 
-#: ckanext/recombinant/controller.py:507
+#: ckanext/recombinant/controller.py:508
 msgid "Sheet {0} Row {1}:"
 msgstr ""
 
-#: ckanext/recombinant/controller.py:511
+#: ckanext/recombinant/controller.py:512
 msgid "Error while importing data: {0}"
 msgstr ""
 
-#: ckanext/recombinant/controller.py:514
+#: ckanext/recombinant/controller.py:515
 msgid "The template uploaded is empty"
 msgstr ""
 
@@ -132,40 +132,39 @@ msgid "Recombinant dataset type not found"
 msgstr ""
 
 #: ckanext/recombinant/logic.py:164
-#, python-format
-msgid "Multiple datasets exist for type %s"
+msgid "Multiple datasets exist for type {0} org {1}"
 msgstr ""
 
-#: ckanext/recombinant/write_excel.py:312
+#: ckanext/recombinant/write_excel.py:316
 msgid "e.g."
 msgstr ""
 
-#: ckanext/recombinant/write_excel.py:537 ckanext/recombinant/write_excel_v2.py:292
+#: ckanext/recombinant/write_excel.py:547 ckanext/recombinant/write_excel_v2.py:292
 msgid "ID"
 msgstr ""
 
-#: ckanext/recombinant/write_excel.py:541 ckanext/recombinant/write_excel_v2.py:296
+#: ckanext/recombinant/write_excel.py:551 ckanext/recombinant/write_excel_v2.py:296
 msgid "Description"
 msgstr ""
 
-#: ckanext/recombinant/write_excel.py:545 ckanext/recombinant/write_excel_v2.py:300
+#: ckanext/recombinant/write_excel.py:555 ckanext/recombinant/write_excel_v2.py:300
 msgid "Obligation"
 msgstr ""
 
-#: ckanext/recombinant/write_excel.py:549
+#: ckanext/recombinant/write_excel.py:559
 msgid "Validation"
 msgstr ""
 
-#: ckanext/recombinant/write_excel.py:553 ckanext/recombinant/write_excel_v2.py:304
+#: ckanext/recombinant/write_excel.py:563 ckanext/recombinant/write_excel_v2.py:304
 msgid "Format"
 msgstr ""
 
-#: ckanext/recombinant/write_excel.py:557 ckanext/recombinant/write_excel_v2.py:308
+#: ckanext/recombinant/write_excel.py:567 ckanext/recombinant/write_excel_v2.py:308
 msgid "Values"
 msgstr ""
 
-#: ckanext/recombinant/templates/recombinant/resource_edit.html:67
-#: ckanext/recombinant/write_excel.py:586
+#: ckanext/recombinant/templates/recombinant/resource_edit.html:68
+#: ckanext/recombinant/write_excel.py:596
 msgid "Reference"
 msgstr ""
 
@@ -197,29 +196,34 @@ msgid "rows"
 msgstr ""
 
 #: ckanext/recombinant/templates/recombinant/resource_edit.html:45
-#: ckanext/recombinant/templates/recombinant/resource_edit.html:87
+#: ckanext/recombinant/templates/recombinant/resource_edit.html:98
 msgid "Import"
 msgstr ""
 
-#: ckanext/recombinant/templates/recombinant/resource_edit.html:59
+#: ckanext/recombinant/templates/recombinant/resource_edit.html:60
 #: ckanext/recombinant/templates/recombinant/snippets/delete.html:45
 msgid "Delete"
 msgstr ""
 
-#: ckanext/recombinant/templates/recombinant/resource_edit.html:75
+#: ckanext/recombinant/templates/recombinant/resource_edit.html:76
 msgid "API Access"
 msgstr ""
 
-#: ckanext/recombinant/templates/recombinant/resource_edit.html:89
+#: ckanext/recombinant/templates/recombinant/resource_edit.html:83
+#: ckanext/recombinant/templates/recombinant/resource_edit.html:87
+msgid "Activity Stream"
+msgstr ""
+
+#: ckanext/recombinant/templates/recombinant/resource_edit.html:100
 #: ckanext/recombinant/templates/recombinant/snippets/xls_upload.html:3
 msgid "Create and update records"
 msgstr ""
 
-#: ckanext/recombinant/templates/recombinant/resource_edit.html:91
+#: ckanext/recombinant/templates/recombinant/resource_edit.html:102
 msgid "No records have been created for this organization"
 msgstr ""
 
-#: ckanext/recombinant/templates/recombinant/resource_edit.html:92
+#: ckanext/recombinant/templates/recombinant/resource_edit.html:104
 msgid "Get started…"
 msgstr ""
 
@@ -291,10 +295,10 @@ msgstr ""
 #: ckanext/recombinant/templates/recombinant/snippets/api_access.html:137
 msgid ""
 "Remove the record returned by passing the same parameters to the "
-"\"datastore_delete\" endpoint instead of \"datastore_search\"."
+"\"datastore_records_delete\" endpoint instead of \"datastore_search\"."
 msgstr ""
 
-#: ckanext/recombinant/templates/recombinant/snippets/api_access.html:163
+#: ckanext/recombinant/templates/recombinant/snippets/api_access.html:172
 msgid ""
 "If you have modified these API Access instructions for another programming "
 "language please send them to <a href=\"mailto:open-ouvert@tbs-sct.gc.ca"
@@ -375,7 +379,7 @@ msgstr ""
 msgid ""
 "To ensure the validation rules within the template are maintained, please "
 "paste your data using the “Paste Values” function. This can be done by right-"
-"clicking, selecting <kbd>Paste Special</kbd> and then clicking "
-"<kbd>Unicode Text</kbd>."
+"clicking, selecting <kbd>Paste Special</kbd> and then clicking <kbd>Unicode "
+"Text</kbd>."
 msgstr ""
 

--- a/ckanext/recombinant/i18n/fr/LC_MESSAGES/ckanext-recombinant.po
+++ b/ckanext/recombinant/i18n/fr/LC_MESSAGES/ckanext-recombinant.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ckanext-recombinant 2.0.0.dev0\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-05-14 13:59-0400\n"
+"POT-Creation-Date: 2023-01-26 15:39+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: fr\n"
@@ -19,11 +19,11 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.3.4\n"
 
-#: ckanext/recombinant/controller.py:55
+#: ckanext/recombinant/controller.py:54
 msgid "No errors found."
 msgstr "Aucune erreur trouvée."
 
-#: ckanext/recombinant/controller.py:59
+#: ckanext/recombinant/controller.py:58
 msgid "Your file was successfully uploaded into the central system."
 msgstr "Votre fichier a été téléchargé avec succès dans le système central."
 
@@ -48,43 +48,43 @@ msgstr "Aucun document correspondant n’a été trouvé \"%s\""
 msgid "Multiple matching records found"
 msgstr "Plusieurs documents correspondants trouvés"
 
-#: ckanext/recombinant/controller.py:163
+#: ckanext/recombinant/controller.py:164
 msgid "{num} deleted."
 msgstr "{num} supprimé"
 
-#: ckanext/recombinant/controller.py:183 ckanext/recombinant/controller.py:194
+#: ckanext/recombinant/controller.py:184 ckanext/recombinant/controller.py:195
 msgid "Not found"
 msgstr "Non trouvé"
 
-#: ckanext/recombinant/controller.py:220
+#: ckanext/recombinant/controller.py:221
 msgid "Not authorized"
 msgstr "Non autorisé"
 
-#: ckanext/recombinant/controller.py:240 ckanext/recombinant/controller.py:252
+#: ckanext/recombinant/controller.py:241 ckanext/recombinant/controller.py:253
 msgid "Recombinant dataset_type not found"
 msgstr "Type de jeux de données recombinant_non trouvé"
 
-#: ckanext/recombinant/controller.py:263 ckanext/recombinant/controller.py:286
+#: ckanext/recombinant/controller.py:264 ckanext/recombinant/controller.py:287
 msgid "title"
 msgstr "titre"
 
-#: ckanext/recombinant/controller.py:264
+#: ckanext/recombinant/controller.py:265
 msgid "notes"
 msgstr "notes"
 
-#: ckanext/recombinant/controller.py:344
+#: ckanext/recombinant/controller.py:345
 msgid "No organizations found"
 msgstr "Aucune organisation trouvée"
 
-#: ckanext/recombinant/controller.py:348 ckanext/recombinant/controller.py:361
+#: ckanext/recombinant/controller.py:349 ckanext/recombinant/controller.py:362
 msgid "Recombinant resource_name not found"
 msgstr "Nom de la ressource recombinante_non trouvé"
 
-#: ckanext/recombinant/controller.py:389
+#: ckanext/recombinant/controller.py:390
 msgid "Resource not found"
 msgstr "Ressource non trouvée"
 
-#: ckanext/recombinant/controller.py:431
+#: ckanext/recombinant/controller.py:432
 msgid ""
 "The server encountered a problem processing the file uploaded. Please try"
 " copying your data into the latest version of the template and uploading "
@@ -97,13 +97,13 @@ msgstr ""
 "persiste, envoyez votre fichier Excel à open-ouvert@… afin que nous "
 "puissions faire enquête."
 
-#: ckanext/recombinant/controller.py:438
+#: ckanext/recombinant/controller.py:439
 msgid ""
 "Invalid file for this data type. Sheet must be labeled \"{0}\", but you "
 "supplied a sheet labeled \"{1}\""
 msgstr ""
 
-#: ckanext/recombinant/controller.py:445
+#: ckanext/recombinant/controller.py:446
 msgid ""
 "Invalid sheet for this organization. Sheet must be labeled for {0}, but "
 "you supplied a sheet for {1}"
@@ -111,26 +111,27 @@ msgstr ""
 "La feuille n'est pas valide pour cette organisation. La feuille doit être"
 " étiquetée pour {0}, mais vous avez fourni une feuille pour {1}"
 
-#: ckanext/recombinant/controller.py:461
+#: ckanext/recombinant/controller.py:462
 msgid ""
 "This template is out of date. Please try copying your data into the "
 "latest version of the template and uploading again. If this problem "
 "continues, send your Excel file to open-ouvert@tbs-sct.gc.ca so we may "
 "investigate."
-msgstr "Ce modèle est obsolète. Veuillez essayer de copier vos données dans "
-"la dernière version du modèle et de le téléverser à nouveau. Si ce problème "
-"persiste, envoyez votre fichier Excel à open-ouvert@tbs-sct.gc.ca afin que "
-"nous puissions trouver le problème."
+msgstr ""
+"Ce modèle est obsolète. Veuillez essayer de copier vos données dans la "
+"dernière version du modèle et de le téléverser à nouveau. Si ce problème "
+"persiste, envoyez votre fichier Excel à open-ouvert@tbs-sct.gc.ca afin "
+"que nous puissions trouver le problème."
 
-#: ckanext/recombinant/controller.py:507
+#: ckanext/recombinant/controller.py:508
 msgid "Sheet {0} Row {1}:"
 msgstr "Feuille {0} Rangée {1} :"
 
-#: ckanext/recombinant/controller.py:511
+#: ckanext/recombinant/controller.py:512
 msgid "Error while importing data: {0}"
 msgstr "Erreur lors de l’importation des données: {0}"
 
-#: ckanext/recombinant/controller.py:514
+#: ckanext/recombinant/controller.py:515
 msgid "The template uploaded is empty"
 msgstr "Le modèle que vous avez soumis est vide"
 
@@ -145,44 +146,44 @@ msgstr "Type de jeux de données recombinant non trouvé"
 
 #: ckanext/recombinant/logic.py:164
 #, python-format
-msgid "Multiple datasets exist for type %s"
-msgstr "Plusieurs jeux de données existent pour le type %s."
+msgid "Multiple datasets exist for type {0} org {1}"
+msgstr "Plusieurs jeux de données existent pour le type {0} org {1}."
 
-#: ckanext/recombinant/write_excel.py:312
+#: ckanext/recombinant/write_excel.py:316
 msgid "e.g."
 msgstr "ex."
 
-#: ckanext/recombinant/write_excel.py:537
+#: ckanext/recombinant/write_excel.py:547
 #: ckanext/recombinant/write_excel_v2.py:292
 msgid "ID"
 msgstr "Identifiant"
 
-#: ckanext/recombinant/write_excel.py:541
+#: ckanext/recombinant/write_excel.py:551
 #: ckanext/recombinant/write_excel_v2.py:296
 msgid "Description"
 msgstr "Description"
 
-#: ckanext/recombinant/write_excel.py:545
+#: ckanext/recombinant/write_excel.py:555
 #: ckanext/recombinant/write_excel_v2.py:300
 msgid "Obligation"
 msgstr "Obligation"
 
-#: ckanext/recombinant/write_excel.py:549
+#: ckanext/recombinant/write_excel.py:559
 msgid "Validation"
 msgstr "Validation"
 
-#: ckanext/recombinant/write_excel.py:553
+#: ckanext/recombinant/write_excel.py:563
 #: ckanext/recombinant/write_excel_v2.py:304
 msgid "Format"
 msgstr "Format"
 
-#: ckanext/recombinant/write_excel.py:557
+#: ckanext/recombinant/write_excel.py:567
 #: ckanext/recombinant/write_excel_v2.py:308
 msgid "Values"
 msgstr "Valeurs"
 
-#: ckanext/recombinant/templates/recombinant/resource_edit.html:67
-#: ckanext/recombinant/write_excel.py:586
+#: ckanext/recombinant/templates/recombinant/resource_edit.html:68
+#: ckanext/recombinant/write_excel.py:596
 msgid "Reference"
 msgstr "Référence"
 
@@ -222,29 +223,34 @@ msgid "rows"
 msgstr "lignes"
 
 #: ckanext/recombinant/templates/recombinant/resource_edit.html:45
-#: ckanext/recombinant/templates/recombinant/resource_edit.html:87
+#: ckanext/recombinant/templates/recombinant/resource_edit.html:98
 msgid "Import"
 msgstr "Importer"
 
-#: ckanext/recombinant/templates/recombinant/resource_edit.html:59
+#: ckanext/recombinant/templates/recombinant/resource_edit.html:60
 #: ckanext/recombinant/templates/recombinant/snippets/delete.html:45
 msgid "Delete"
 msgstr "Supprimer"
 
-#: ckanext/recombinant/templates/recombinant/resource_edit.html:75
+#: ckanext/recombinant/templates/recombinant/resource_edit.html:76
 msgid "API Access"
 msgstr "Accès par API"
 
-#: ckanext/recombinant/templates/recombinant/resource_edit.html:89
+#: ckanext/recombinant/templates/recombinant/resource_edit.html:83
+#: ckanext/recombinant/templates/recombinant/resource_edit.html:87
+msgid "Activity Stream"
+msgstr "Flux d'Activités"
+
+#: ckanext/recombinant/templates/recombinant/resource_edit.html:100
 #: ckanext/recombinant/templates/recombinant/snippets/xls_upload.html:3
 msgid "Create and update records"
 msgstr "Créer et mettre à jour un dossier"
 
-#: ckanext/recombinant/templates/recombinant/resource_edit.html:91
+#: ckanext/recombinant/templates/recombinant/resource_edit.html:102
 msgid "No records have been created for this organization"
 msgstr "Aucun enregistrement n'a été créé pour cette organisation"
 
-#: ckanext/recombinant/templates/recombinant/resource_edit.html:92
+#: ckanext/recombinant/templates/recombinant/resource_edit.html:104
 msgid "Get started…"
 msgstr "Commencer…"
 
@@ -335,12 +341,13 @@ msgstr ""
 #: ckanext/recombinant/templates/recombinant/snippets/api_access.html:137
 msgid ""
 "Remove the record returned by passing the same parameters to the "
-"\"datastore_delete\" endpoint instead of \"datastore_search\"."
+"\"datastore_records_delete\" endpoint instead of \"datastore_search\"."
 msgstr ""
 "Supprimez le dossier retourné en appliquant les mêmes paramètres au point"
-" de terminaison « datastore_delete » plutôt que « datastore_search »."
+" de terminaison « datastore_records_delete » plutôt que « "
+"datastore_search »."
 
-#: ckanext/recombinant/templates/recombinant/snippets/api_access.html:163
+#: ckanext/recombinant/templates/recombinant/snippets/api_access.html:172
 msgid ""
 "If you have modified these API Access instructions for another "
 "programming language please send them to <a href=\"mailto:open-ouvert"

--- a/ckanext/recombinant/templates/recombinant/snippets/api_access.html
+++ b/ckanext/recombinant/templates/recombinant/snippets/api_access.html
@@ -96,7 +96,45 @@ result = ckan.action.datastore_upsert(
 )</pre>
 
   <h4>{{ _("Delete Records") }}</h4>
-  <p>{% trans %}Remove the record by passing the resource_id and any filters to the "datastore_records_delete" endpoint.{% endtrans %}</p>
+  <p>{% trans %}First verify that the record you would like to remove is present with the "datastore_search" endpoint{% endtrans %}<p>
+
+  <h5>{{ _("Example:") }}</h5>
+  <pre class="curl"
+>curl {{ g.site_url }}/api/action/datastore_search \
+  -H"Authorization:$API_KEY" -d '
+{
+  "resource_id": "{{ resource_id }}",
+  "filters": {
+{{ h.recombinant_example(resource.name, 'filter_one', indent=4) }}
+  }
+}'
+</pre>
+  <pre class="powershell"
+>$json = @'
+{
+  "resource_id": "{{ resource_id }}",
+  "records": [{
+{{ h.recombinant_example(resource.name, 'filter_one', indent=4) }}
+  }]
+}
+'@
+$response = Invoke-RestMethod {{ g.site_url }}/api/action/datastore_search `
+  -Method Post -Body $json -Headers @{"Authorization"="$API_KEY"}
+$response.result.records
+</pre>
+  <pre class="python"
+>from ckanapi import RemoteCKAN
+from pprint import pprint
+ckan = RemoteCKAN('{{ g.site_url }}', apikey=API_KEY)
+result = ckan.action.datastore_search(
+    resource_id="{{ resource_id }}",
+    filters={
+{{ h.recombinant_example(resource.name, 'filter_one', indent=8) }}
+    }
+)
+pprint(result['records'])</code></pre>
+
+  <p>{% trans %}Remove the record returned by passing the same parameters to the "datastore_records_delete" endpoint instead of "datastore_search".{% endtrans %}</p>
 
   <h5>{{ _("Example:") }}</h5>
   <pre class="curl"

--- a/ckanext/recombinant/templates/recombinant/snippets/api_access.html
+++ b/ckanext/recombinant/templates/recombinant/snippets/api_access.html
@@ -96,11 +96,11 @@ result = ckan.action.datastore_upsert(
 )</pre>
 
   <h4>{{ _("Delete Records") }}</h4>
-  <p>{% trans %}First verify that the record you would like to remove is present with the "datastore_search" endpoint{% endtrans %}<p>
+  <p>{% trans %}Remove the record by passing the resource_id and any filters to the "datastore_records_delete" endpoint.{% endtrans %}</p>
 
   <h5>{{ _("Example:") }}</h5>
   <pre class="curl"
->curl {{ g.site_url }}/api/action/datastore_search \
+>curl {{ g.site_url }}/api/action/datastore_records_delete \
  -H"Authorization:$API_KEY" -d '
 {
   "resource_id": "{{ resource_id }}",
@@ -113,46 +113,17 @@ result = ckan.action.datastore_upsert(
 >$json = @'
 {
   "resource_id": "{{ resource_id }}",
-  "records": [{
-{{ h.recombinant_example(resource.name, 'filter_one', indent=4) }}
-  }]
-}
-'@
-$response = Invoke-RestMethod {{ g.site_url }}/api/action/datastore_search `
-  -Method Post -Body $json -Headers @{"Authorization"="$API_KEY"}
-$response.result.records
-</pre>
-  <pre class="python"
->from ckanapi import RemoteCKAN
-from pprint import pprint
-ckan = RemoteCKAN('{{ g.site_url }}', apikey=API_KEY)
-result = ckan.action.datastore_search(
-    resource_id="{{ resource_id }}",
-    filters={
-{{ h.recombinant_example(resource.name, 'filter_one', indent=8) }}
-    }
-)
-pprint(result['records'])</code></pre>
-
-  <p>{% trans %}Remove the record returned by passing the same parameters to the "datastore_delete" endpoint instead of "datastore_search".{% endtrans %}</p>
-
-  <h5>{{ _("Example:") }}</h5>
-  <pre class="bash"
->curl {{ g.site_url }}/api/action/datastore_delete \
- -H"Authorization:$API_KEY" -d '
-{
-  "resource_id": "{{ resource_id }}",
   "filters": {
 {{ h.recombinant_example(resource.name, 'filter_one', indent=4) }}
   }
-}'
-</pre>
-  <pre class="powershell"
->$response = Invoke-RestMethod {{ g.site_url }}/api/action/datastore_delete `
+'@
+>$response = Invoke-RestMethod {{ g.site_url }}/api/action/datastore_records_delete `
   -Method Post -Body $json -Headers @{"Authorization"="$API_KEY"}
 </pre>
   <pre class="python"
->ckan.action.datastore_delete(
+>from ckanapi import RemoteCKAN
+ckan = RemoteCKAN('{{ g.site_url }}', apikey=API_KEY)
+ckan.action.datastore_records_delete(
     resource_id="{{ resource_id }}",
     filters={
 {{ h.recombinant_example(resource.name, 'filter_one', indent=8) }}


### PR DESCRIPTION
Updated API help text for deleted PD records;

I do not think we need the help text regarding the `datastore_search` in the Delete section of the help.  The `datastore_records_delete` action will throw an error that the resource does not exist in the datastore.