### PR TITLE
Even More 2.9 Compatibility

### DIFF
--- a/ckanext/recombinant/templates/recombinant/resource_edit.html
+++ b/ckanext/recombinant/templates/recombinant/resource_edit.html
@@ -83,7 +83,7 @@
             {{ _("Activity Stream") }}
           </summary>
           {% block activity_stream %}
-            <a id="activity-stream-link" href="{{ h.url_for(dataset.dataset_type + '.activity', id=dataset.id) }}">
+            <a id="activity-stream-link" href="{{ h.url_for('dataset.activity', id=dataset.id) }}">
               {{ _('Activity Stream') }}
             </a>
           {% endblock %}

--- a/ckanext/recombinant/views.py
+++ b/ckanext/recombinant/views.py
@@ -7,9 +7,14 @@ from logging import getLogger
 
 from ckan.plugins.toolkit import _, asbool, aslist, config
 
-from ckan.lib.base import (c, render, model, request, h,
-    abort)
-from ckan.controllers.package import PackageController
+from ckan.lib.base import (
+    c,
+    render,
+    model,
+    request,
+    h,
+    abort
+)
 from ckan.logic import ValidationError, NotAuthorized
 
 from ckan.views.dataset import _get_package_type
@@ -376,7 +381,7 @@ def dataset_redirect(package_type, id):
 @recombinant.route('/recombinant/<resource_name>/<owner_org>', methods=['GET', 'POST'])
 def preview_table(resource_name, owner_org, errors=None):
     if not c.user:
-        h.redirect_to(controller='user', action='login')
+        h.redirect_to('user.login')
 
     lc = ckanapi.LocalCKAN(username=c.user)
     try:

--- a/ckanext/recombinant/views.py
+++ b/ckanext/recombinant/views.py
@@ -65,7 +65,7 @@ def upload(id):
                 ))
 
         return h.redirect_to(dataset['type'] + '.read', id=id)
-    except BadExcelData, e:
+    except BadExcelData as e:
         org = lc.action.organization_show(id=dataset['owner_org'])
         return preview_table(
             resource_name=dataset['resources'][0]['name'],
@@ -381,7 +381,7 @@ def dataset_redirect(package_type, id):
 @recombinant.route('/recombinant/<resource_name>/<owner_org>', methods=['GET', 'POST'])
 def preview_table(resource_name, owner_org, errors=None):
     if not c.user:
-        h.redirect_to('user.login')
+        return h.redirect_to('user.login')
 
     lc = ckanapi.LocalCKAN(username=c.user)
     try:


### PR DESCRIPTION
@wardi The activity stream for PD types does not seem to be implemented, but will work fine as `dataset/<pkg_id>`

Let me know if this is fine, or if we should do it the more proper way and implement the activity blueprint method in the recombinant views and keep the `dataset.dataset_type + '.activity'` in the template.