### PR TITLE
Refresh Resource in DataStore

### DIFF
--- a/ckanext/recombinant/templates/recombinant/resource_edit.html
+++ b/ckanext/recombinant/templates/recombinant/resource_edit.html
@@ -23,8 +23,8 @@
       {% for r in dataset.resources %}
         <li {% if r.id == resource.id %}class="active"{% endif %}>{%
           link_for _(r.description) ~ ': ' ~
-            ngettext("%(num)d "+_('row'), "%(num)d "+_('rows'), r.datastore_rows)
-            |format(num=r.datastore_rows),
+            ngettext("%(num)d "+_('row'), "%(num)d "+_('rows'), r.get('datastore_rows', 0))
+            |format(num=r.get('datastore_rows', 0)),
           named_route='recombinant.preview_table',
           resource_name=r.name, owner_org=dataset.owner_org %}</li>
       {% endfor %}
@@ -36,60 +36,80 @@
     organization_display_name=organization_display_name %}
 
   {% if dataset %}
-    {% set refs = h.recombinant_choice_fields(resource.name) %}
-    <div class="wb-tabs">
-      <div class="tabpanels">
-        {% block update_panel %}
+    {% if has_datastore_table %}
+      {% set refs = h.recombinant_choice_fields(resource.name) %}
+      <div class="wb-tabs">
+        <div class="tabpanels">
+          {% block update_panel %}
+            <details id="update" {% if errors %}open="open"{% endif %}>
+              <summary><span class="glyphicon glyphicon-import"></span>
+                {{ _("Import") }}
+              </summary>
+              {% if h.check_access('package_update', {'id': dataset.id }) %}
+                {% snippet "recombinant/snippets/xls_upload.html",
+                  pkg=dataset, resource=resource, errors=errors %}
+              {% else %}
+                {% snippet "recombinant/snippets/xls_download.html",
+                  pkg=dataset, errors=errors %}
+              {% endif %}
+              {% block notices %}{% endblock %}
+            </details>
+          {% endblock %}
+          {% if h.check_access('package_update', {'id': dataset.id }) %}
+            <details {% if delete_errors %}open="open"{% endif %} id="delete">
+              <summary><span class="glyphicon glyphicon-remove"></span>
+                {{ _("Delete") }}</summary>
+              {% snippet "recombinant/snippets/delete.html",
+                pkg=dataset, res=resource, errors=delete_errors, filters=filters %}
+            </details>
+          {% endif %}
+          {% if refs %}
+            <details id="reference">
+              <summary><span class="glyphicon glyphicon-th-list"></span>
+                {{ _("Reference") }}
+              </summary>
+              {% snippet "recombinant/snippets/choices_reference.html",
+                refs=refs, dataset_type=dataset.dataset_type %}
+            </details>
+          {% endif %}
+          <details id="api">
+            <summary><span class="glyphicon glyphicon-wrench"></span>
+              {{ _("API Access") }}
+            </summary>
+            {% snippet "recombinant/snippets/api_access.html",
+              pkg=dataset, username=c.userobj.name, resource=resource %}
+          </details>
+          <details id="activity">
+            <summary><span class="glyphicon glyphicon-time"></span>
+              {{ _("Activity Stream") }}
+            </summary>
+            {% block activity_stream %}
+              <a id="activity-stream-link" href="{{ h.url_for(dataset.dataset_type ~ '.activity', id=dataset.id) }}">
+                {{ _('Activity Stream') }}
+              </a>
+            {% endblock %}
+          </details>
+        </div>
+      </div>
+    {% else %}
+      <div class="wb-tabs">
+        <div class="tabpanels">
           <details id="update" {% if errors %}open="open"{% endif %}>
             <summary><span class="glyphicon glyphicon-import"></span>
               {{ _("Import") }}
             </summary>
-            {% if h.check_access('package_update', {'id': dataset.id }) %}
-              {% snippet "recombinant/snippets/xls_upload.html",
-                pkg=dataset, resource=resource, errors=errors %}
-            {% else %}
-              {% snippet "recombinant/snippets/xls_download.html",
-                pkg=dataset, errors=errors %}
-            {% endif %}
-            {% block notices %}{% endblock %}
+            <h3>{{_("Something went wrong with retrieving your records")}}</h3>
+            <div class="col-md-12">
+              <p>{{_("We were unable to find your records in our database. Please contact support to inquire about this. Or click the Restart button bellow.")}}</p>
+              <form id="create-pd-resource" method="post">
+                <button type="submit" class="btn btn-default" name="refresh">{{_('Restart…')}}</button>
+              </form>
+              {{ self.notices() }}
+            </div>
           </details>
-        {% endblock %}
-        {% if h.check_access('package_update', {'id': dataset.id }) %}
-          <details {% if delete_errors %}open="open"{% endif %} id="delete">
-            <summary><span class="glyphicon glyphicon-remove"></span>
-              {{ _("Delete") }}</summary>
-            {% snippet "recombinant/snippets/delete.html",
-              pkg=dataset, res=resource, errors=delete_errors, filters=filters %}
-          </details>
-        {% endif %}
-        {% if refs %}
-          <details id="reference">
-            <summary><span class="glyphicon glyphicon-th-list"></span>
-              {{ _("Reference") }}
-            </summary>
-            {% snippet "recombinant/snippets/choices_reference.html",
-              refs=refs, dataset_type=dataset.dataset_type %}
-          </details>
-        {% endif %}
-        <details id="api">
-          <summary><span class="glyphicon glyphicon-wrench"></span>
-            {{ _("API Access") }}
-          </summary>
-          {% snippet "recombinant/snippets/api_access.html",
-            pkg=dataset, username=c.userobj.name, resource=resource %}
-        </details>
-        <details id="activity">
-          <summary><span class="glyphicon glyphicon-time"></span>
-            {{ _("Activity Stream") }}
-          </summary>
-          {% block activity_stream %}
-            <a id="activity-stream-link" href="{{ h.url_for(dataset.dataset_type ~ '.activity', id=dataset.id) }}">
-              {{ _('Activity Stream') }}
-            </a>
-          {% endblock %}
-        </details>
+        </div>
       </div>
-    </div>
+    {% endif %}
   {% else %}
     <div class="wb-tabs">
       <div class="tabpanels">


### PR DESCRIPTION
feat(views): refresh resource;

- Catch none existing DS table and allow user refresh.

This catches the cases in which the Datastore table has been deleted for a Recombinant resource. It will output a new form notifying the user that something went wrong and to contact support. And then gives them a button which runs a `recombinant_update` for that type and org.