### PR TITLE
Use Recombinant DataDicts for Datatables Columns

### DIFF
--- a/.github/workflows/change_log.yml
+++ b/.github/workflows/change_log.yml
@@ -1,0 +1,43 @@
+name: Changelog Entry
+on: [pull_request]
+
+permissions:
+  contents: read
+
+jobs:
+  check_file:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Check Chanelog Exists
+        run: |
+          if [[ $(ls ./changes/${{ github.event.number }}.*) ]]; then
+            echo -e "\n"
+            echo -e "\033[0;36mINFO: changelog for PR ${{ github.event.number }} exists.\033[0;0m"
+            echo -e "\n"
+            exit 0
+          else
+            echo -e "\n"
+            echo -e "\033[0;31mERROR: changelog for PR ${{ github.event.number }} does not exist.\033[0;0m"
+            echo -e "\n"
+            exit 1
+          fi
+
+      - name: Check Changelog Extension
+        run: |
+          fullfile=$(ls ./changes/${{ github.event.number }}.*)
+          filename=$(basename -- "$fullfile")
+          extension="${filename##*.}"
+          allowed_types='[ "fix", "bugfix", "hotfix", "feature", "misc", "changes", "migration", "removal" ]'
+          if [[ $allowed_types =~ "\"$extension\"" ]]; then
+            echo -e "\n"
+            echo -e "\033[0;36mINFO: extension ${extension} accepted.\033[0;0m"
+            echo -e "\n"
+            exit 0
+          else
+            echo -e "\n"
+            echo -e "\033[0;31mERROR: changelog file ending in ${extension} not supported.\033[0;0m"
+            echo -e "\n"
+            exit 1
+          fi

--- a/changes/120.feature
+++ b/changes/120.feature
@@ -1,0 +1,1 @@
+Published Resources will now use the Recombinant Data Dictionary for the Datatables Views' column headers.

--- a/ckanext/recombinant/templates/datatables/datatables_view.html
+++ b/ckanext/recombinant/templates/datatables/datatables_view.html
@@ -7,7 +7,7 @@
 
     {% set chromo_keyed = {} %}
     {% for recombinant_field in chromo.fields %}
-      {% set _ = chromo_keyed.update({recombinant_field.datastore_id: {'description': recombinant_field.description,
+      {% do chromo_keyed.update({recombinant_field.datastore_id: {'description': recombinant_field.description,
                                                                        'label': recombinant_field.label}}) %}
     {% endfor %}
 

--- a/ckanext/recombinant/templates/datatables/datatables_view.html
+++ b/ckanext/recombinant/templates/datatables/datatables_view.html
@@ -50,7 +50,7 @@
           {% endif %}
           <th scope="col">
             {{ label }}&nbsp;
-            {% if description|length %}
+            {% if description %}
               <i class="fa fa-info-circle" title="{{ h.markdown_extract(description, 300) }}"></i>
             {% endif %}
             &nbsp;

--- a/ckanext/recombinant/templates/datatables/datatables_view.html
+++ b/ckanext/recombinant/templates/datatables/datatables_view.html
@@ -23,7 +23,7 @@
           {% set label = h.recombinant_language_text(chromo_keyed[field.id].label) | trim %}
           <th scope="col">
             {{ label }}&nbsp;
-            {% if description|length %}
+            {% if description %}
               <i class="fa fa-info-circle" title="{{ h.markdown_extract(description, 300) }}"></i>
             {% endif %}
             &nbsp;

--- a/ckanext/recombinant/templates/datatables/datatables_view.html
+++ b/ckanext/recombinant/templates/datatables/datatables_view.html
@@ -1,0 +1,70 @@
+{% ckan_extends %}
+
+{%- block datatable_field_headers -%}
+
+  {% set chromo = h.recombinant_published_resource_chromo(resource.id) %}
+  {% if chromo %}
+
+    {% set chromo_keyed = {} %}
+    {% for recombinant_field in chromo.fields %}
+      {% set _ = chromo_keyed.update({recombinant_field.datastore_id: {'description': recombinant_field.description,
+                                                                       'label': recombinant_field.label}}) %}
+    {% endfor %}
+
+    {%- set datadictionary_fields = h.datastore_dictionary(resource.id) -%}
+
+    {% for field in datadictionary_fields %}
+
+      {% if 'show_fields' not in resource_view or field.id in resource_view.show_fields -%}
+
+        {% if field.id in chromo_keyed %}
+        {# the DS field is a Recombinant field, use chromo #}
+          {% set description = h.recombinant_language_text(chromo_keyed[field.id].description) | replace('\n', '<br>' | safe) %}
+          {% set label = h.recombinant_language_text(chromo_keyed[field.id].label) | trim %}
+          <th scope="col">
+            {{ label }}&nbsp;
+            {% if description|length %}
+              <i class="fa fa-info-circle" title="{{ h.markdown_extract(description, 300) }}"></i>
+            {% endif %}
+            &nbsp;
+          </th>
+        {% else %}
+        {# the DS field is NOT a Recombinant field, use normal data dictionary (with lang support) #}
+          {% set translated_label = 'label_' + h.lang() %}
+          {% set translated_description = 'notes_' + h.lang() %}
+          {% set label = field.id|replace(" ", nbspval) %}
+          {% set description = '' %}
+          {% if data_dictionary_labels and field.info is defined %}
+            {# set label #}
+            {% if field.info[translated_label]|length %}
+              {% set label = field.info[translated_label] | trim %}
+            {% elif field.info['label']|length %}
+              {% set label = field.info['label'] | trim %}
+            {% endif %}
+            {# set description #}
+            {% if field.info[translated_description]|length %}
+              {% set description = field.info[translated_description] %}
+            {% elif field.info['notes']|length %}
+              {% set description = field.info['notes'] %}
+            {% endif %}
+          {% endif %}
+          <th scope="col">
+            {{ label }}&nbsp;
+            {% if description|length %}
+              <i class="fa fa-info-circle" title="{{ h.markdown_extract(description, 300) }}"></i>
+            {% endif %}
+            &nbsp;
+          </th>
+        {% endif %}
+
+      {%- endif %}
+
+    {% endfor %}
+
+  {% else %}
+
+    {{ super() }}
+
+  {% endif %}
+
+{%- endblock -%}

--- a/ckanext/recombinant/templates/datatables/datatables_view.html
+++ b/ckanext/recombinant/templates/datatables/datatables_view.html
@@ -8,7 +8,7 @@
     {% set chromo_keyed = {} %}
     {% for recombinant_field in chromo.fields %}
       {% do chromo_keyed.update({recombinant_field.datastore_id: {'description': recombinant_field.description,
-                                                                       'label': recombinant_field.label}}) %}
+                                                                  'label': recombinant_field.label}}) %}
     {% endfor %}
 
     {%- set datadictionary_fields = h.datastore_dictionary(resource.id) -%}


### PR DESCRIPTION
feat(templates): use data dict for datatable labels;

- Added `datatables_view` template to use chromo label and descriptions.

req: https://github.com/open-data/ckan/pull/174